### PR TITLE
feat: added useful types for accessing redis methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,9 @@ function builder<T extends Clients>(
     async del(key) {
       await redisCache.del(key);
     },
+    sMembers: (key) => redisCache.sMembers(key),
+    sAdd: (key, members) => redisCache.sAdd(key, members),
+    sRemove: (key, members) => redisCache.sRem(key, members),
     ttl: async (key) => redisCache.pTTL(key),
     keys: (pattern = '*') => keys(pattern),
     reset,


### PR DESCRIPTION
This requires https://github.com/node-cache-manager/node-cache-manager/pull/608 to merge another PR, since the methods I added require the function arguments to be inferred from the Store type in the node-cache-manager library.